### PR TITLE
Fix broken internal links in 2025-1 SRS task

### DIFF
--- a/semestres/2025-1/srs.md
+++ b/semestres/2025-1/srs.md
@@ -10,10 +10,10 @@ En esta tarea, hemos recibido casos con alcances deliberadamente incompletos y a
 
 ## Temas:
 
-- [**Conectados:** Servicios a un clic](./2025-1/conectados.md).
-- [**RunTrack:** plataforma para runners](./2025-1/conectados.md).
-- [**LogisticaGlobal.com:** Gestión de Incidentes Robóticos en Warehouse](./2025-1/logisticaglobal.md).
-- [**Teatro Mora:** Eventos Teatrales](./2025-1/mora.md).
+- [**Conectados:** Servicios a un clic](./conectados.md).
+- [**RunTrack:** plataforma para runners](./runtrack.md).
+- [**LogisticaGlobal.com:** Gestión de Incidentes Robóticos en Warehouse](./logisticaglobal.md).
+- [**Teatro Mora:** Eventos Teatrales](./mora.md).
 ---
 
 **Para el tema elegido (EN EQUIPO) cada estudiante de manera individual debe preparar una Especificación de Requerimientos de Software completa basada en el caso asignado, que incluya los siguientes elementos:**


### PR DESCRIPTION
## Qué cambia
Corrige 4 links internos rotos en `semestres/2025-1/srs.md`:

- Elimina el segmento `2025-1/` sobrante de las rutas (el archivo ya vive en `semestres/2025-1/`, así que las rutas con ese prefijo daban 404).
- Corrige el link de **RunTrack**, que apuntaba a `conectados.md` en vez de `runtrack.md`.

| Antes | Después |
|---|---|
| `./2025-1/conectados.md` | `./conectados.md` |
| `./2025-1/conectados.md` (RunTrack) | `./runtrack.md` |
| `./2025-1/logisticaglobal.md` | `./logisticaglobal.md` |
| `./2025-1/mora.md` | `./mora.md` |

## Verificación
Escaneo de todos los `.md` del repo: **0 links internos rotos** tras el cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
